### PR TITLE
Fix fixed-data-table version number

### DIFF
--- a/team/package.json
+++ b/team/package.json
@@ -15,7 +15,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-runtime": "^6.26.0",
     "file-loader": "^0.8.5",
-    "fixed-data-table": "^0.8.6",
+    "fixed-data-table": "^0.6.5",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.0",


### PR DESCRIPTION
Use the 0.6.5 as the version for `fixed-data=table` so that every one gets the tabular run.